### PR TITLE
Update ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,6 +106,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }
+
       # Pull the latest image that was just built
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
add login to ghtc docker image repository, issue with auth:
 Error response from daemon: Head "https://ghcr.io/v2/anielskieoczko/ecommerce_backend/manifests/1.2.1": unauthorized